### PR TITLE
Bring up annotation-driven channel generation in MIDAS simulation mapping

### DIFF
--- a/src/main/scala/firrtl/transforms/fame/FAMEDefaults.scala
+++ b/src/main/scala/firrtl/transforms/fame/FAMEDefaults.scala
@@ -26,9 +26,10 @@ class FAMEDefaults extends Transform {
     val channelNS = Namespace(channelNames)
     def isGlobal(topPort: Port) = globalSignals.contains(topPort.name)
     def isBound(topPort: Port) = analysis.channelsByPort.contains(analysis.topTarget.ref(topPort.name))
-    val defaultExtChannelAnnos = topModule.ports.filterNot(isGlobal).filterNot(isBound).map({
-      case Port(_, name, Input, _) => FAMEChannelAnnotation(channelNS.newName(name), WireChannel, None, Some(Seq(analysis.topTarget.ref(name))))
-      case Port(_, name, Output, _) => FAMEChannelAnnotation(channelNS.newName(name), WireChannel, Some(Seq(analysis.topTarget.ref(name))), None)
+    val defaultExtChannelAnnos = topModule.ports.filterNot(isGlobal).filterNot(isBound).flatMap({
+      case Port(_, _, _, ClockType) => None // FIXME: Reject the clock in RC's debug interface
+      case Port(_, name, Input, _)  => Some(FAMEChannelAnnotation(channelNS.newName(name), WireChannel, None, Some(Seq(analysis.topTarget.ref(name)))))
+      case Port(_, name, Output, _) => Some(FAMEChannelAnnotation(channelNS.newName(name), WireChannel, Some(Seq(analysis.topTarget.ref(name))), None))
     })
     val channelModules = new LinkedHashSet[String] // TODO: find modules to absorb into channels, don't label as FAME models
     val defaultLoopbackAnnos = new ArrayBuffer[FAMEChannelAnnotation]

--- a/src/main/scala/firrtl/transforms/fame/WrapTop.scala
+++ b/src/main/scala/firrtl/transforms/fame/WrapTop.scala
@@ -35,7 +35,16 @@ class WrapTop extends Transform {
       case fca: FAMEChannelAnnotation =>
         fca.copy(sinks = fca.sinks.map(_.map(_.copy(module = topWrapperName))), sources = fca.sources.map(_.map(_.copy(module = topWrapperName))))
       case a => a
+    }).map({ // Also update targets in info fields
+      case fca @ FAMEChannelAnnotation(_,info@DecoupledForwardChannel(_,_,_,_),_,_) =>
+        fca.copy(channelInfo = info.copy(
+          readySink   = info.readySink.  map(_.copy(module = topWrapperName)),
+          validSource = info.validSource.map(_.copy(module = topWrapperName)),
+          readySource = info.readySource.map(_.copy(module = topWrapperName)),
+          validSink   = info.validSink.  map(_.copy(module = topWrapperName))))
+      case a => a
     })
+
     renames.record(CircuitTarget(topName), topWrapperTarget.targetParent)
     state.copy(circuit = newCircuit, annotations = updatedAnnotations ++ specialPortAnnotations, renames = Some(renames))
   }


### PR DESCRIPTION
There is one hack introduced here which can be fixed when we ultimately go multiclock. 